### PR TITLE
Factor Spall format out into its own package.

### DIFF
--- a/build.py
+++ b/build.py
@@ -37,6 +37,7 @@ print('Compiling...')
 subprocess.run([
     odin,
     'build', 'src',
+    '-collection:formats=formats',
     '-target:js_wasm32',
     f"-out:{wasm_out}",
     *build_str,

--- a/formats/spall/spall.odin
+++ b/formats/spall/spall.odin
@@ -1,0 +1,29 @@
+package spall
+
+MAGIC :: u64(0x0BADF00D)
+
+Header :: struct #packed {
+	magic:          u64,
+	version:        u64,
+	timestamp_unit: f64,
+}
+
+Event_Type :: enum u8 {
+	Begin,
+	End,
+}
+
+Begin_Event :: struct #packed {
+	type: Event_Type,
+	pid:      u32,
+	tid:      u32,
+	time:     f64,
+	name_len: u8,
+}
+
+End_Event :: struct #packed {
+	type: Event_Type,
+	pid:  u32,
+	tid:  u32,
+	time: f64,
+}

--- a/src/binparse.odin
+++ b/src/binparse.odin
@@ -3,6 +3,7 @@ package main
 import "core:fmt"
 import "core:strings"
 import "core:container/queue"
+import "formats:spall"
 
 BinaryState :: enum {
 	PartialRead,
@@ -22,29 +23,6 @@ Parser :: struct {
 
 	intern: strings.Intern,
 	cur_event: Event,
-}
-
-BinEventType :: enum u8 {
-	Begin,
-	End,
-}
-BinHeader :: struct #packed {
-	magic: u64,
-	version: u64,
-	timestamp_unit: f64,
-}
-BeginEvent :: struct #packed {
-	type: BinEventType,
-	pid: u32,
-	tid: u32,
-	time: f64,
-	name_len: u8,
-}
-EndEvent :: struct #packed {
-	type: BinEventType,
-	pid: u32,
-	tid: u32,
-	time: f64,
 }
 
 real_pos :: #force_inline proc(p: ^Parser) -> u32 { return p.pos }
@@ -75,17 +53,17 @@ get_next_event :: proc(p: ^Parser) -> (Event, BinaryState) {
 		return Event{}, .PartialRead
 	}
 
-	type := (^BinEventType)(raw_data(p.data[chunk_pos(p):]))^
+	type := (^spall.Event_Type)(raw_data(p.data[chunk_pos(p):]))^
 	switch type {
 	case .Begin:
-		event_sz := u32(size_of(BeginEvent))
+		event_sz := u32(size_of(spall.Begin_Event))
 		if real_pos(p) + event_sz > p.total_size {
 			return Event{}, .Finished
 		}
 		if int(chunk_pos(p) + event_sz) > len(p.data) {
 			return Event{}, .PartialRead
 		}
-		event := (^BeginEvent)(raw_data(p.data[chunk_pos(p):]))^
+		event := (^spall.Begin_Event)(raw_data(p.data[chunk_pos(p):]))^
 
 		if (real_pos(p) + event_sz + u32(event.name_len)) > p.total_size {
 			return Event{}, .Finished
@@ -111,14 +89,14 @@ get_next_event :: proc(p: ^Parser) -> (Event, BinaryState) {
 		p.pos += u32(event_sz) + u32(event.name_len)
 		return ev, .EventRead
 	case .End:
-		event_sz := u32(size_of(EndEvent))
+		event_sz := u32(size_of(spall.End_Event))
 		if real_pos(p) + event_sz > p.total_size {
 			return Event{}, .Finished
 		}
 		if int(chunk_pos(p) + event_sz) > len(p.data) {
 			return Event{}, .PartialRead
 		}
-		event := (^EndEvent)(raw_data(p.data[chunk_pos(p):]))^
+		event := (^spall.End_Event)(raw_data(p.data[chunk_pos(p):]))^
 
 		ev := Event{
 			type = .End,

--- a/src/config.odin
+++ b/src/config.odin
@@ -6,6 +6,7 @@ import "core:slice"
 import "core:container/queue"
 import "core:mem"
 import "core:strconv"
+import "formats:spall"
 
 start_time: u64
 start_mem: u64
@@ -243,18 +244,18 @@ load_config_chunk :: proc "contextless" (start, total_size: u32, chunk: []u8) {
 	defer free_all(context.temp_allocator)
 
 	if first_chunk {
-		header_sz := size_of(BinHeader)
+		header_sz := size_of(spall.Header)
 		if len(chunk) < header_sz {
 			return
 		}
 		magic := (^u64)(raw_data(chunk))^
 
-		is_json = magic != 0x0BADF00D
+		is_json = magic != spall.MAGIC
 		if is_json {
 			stamp_scale = 1
 			jp = init_json_parser(total_size)
 		} else {
-			hdr := cast(^BinHeader)raw_data(chunk)
+			hdr := cast(^spall.Header)raw_data(chunk)
 			if hdr.version != 0 {
 				return
 			}


### PR DESCRIPTION
- Factor Spall binary format specification out into its own Odin package
- Update main package and `build.py` to use the new package
- Update `tools\json2bin` to use the new package (and also handle `B` + `E` events, not just `X`).